### PR TITLE
Bugfix/remove scib

### DIFF
--- a/docker/openproblems-r-base/README.md
+++ b/docker/openproblems-r-base/README.md
@@ -27,5 +27,4 @@ R packages:
 Python packages:
 
 * rpy2<3.4.0
-* scIB
 * anndata2ri

--- a/docker/openproblems-r-base/requirements.txt
+++ b/docker/openproblems-r-base/requirements.txt
@@ -1,3 +1,2 @@
-git+https://github.com/theislab/scib@master
 rpy2
 anndata2ri>=1.0.6

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ install_requires = [
 
 r_requires = [
     "rpy2",
-    "scIB @ git+https://github.com/theislab/scib@master",
     "anndata2ri>=1.0.6",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ install_requires = [
     "memory-profiler",
     "umap-learn<0.5",
     "colorama>=0.3.9",
+    "packaging",
 ]
 
 r_requires = [


### PR DESCRIPTION
Removing scIB as a core dependency since we no longer use it for scran normalization. Note to @LuckyMD and @danielStrobl that if you're using scIB for the batch normalization task, you will have to add it as a dependency in either `openproblems-python-extras`, `openproblems-r-extras`, or a new Docker image. Note also that scIB's use of scanpy<1.5 breaks `openproblems` dependency on scanpy >= 1.6. 