### PR TITLE
Remove nf-openproblems git submodule

### DIFF
--- a/.github/workflows/run_benchmark.yml
+++ b/.github/workflows/run_benchmark.yml
@@ -94,7 +94,7 @@ jobs:
         TOWER_ACCESS_TOKEN: ${{ secrets.TOWER_ACCESS_KEY }}
         AWS_DEFAULT_REGION: us-west-2
       run: |
-        nextflow run singlecellopenproblems/nf-openproblems -r 472c3a588e92a6c00def62f49bd2173c5512c991 -with-tower -profile aws -work-dir "/mnt/openproblems-nextflow/work${RUN_ID}" -bucket-dir s3://openproblems-nextflow/benchmark
+        nextflow run singlecellopenproblems/nf-openproblems -r master -with-tower -profile aws -work-dir "/mnt/openproblems-nextflow/work${RUN_ID}" -bucket-dir s3://openproblems-nextflow/benchmark
 
     - name: Remove working directory
       if: always()

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "nf-openproblems"]
-	path = nf-openproblems
-	url = git@github.com:singlecellopenproblems/nf-openproblems


### PR DESCRIPTION
As updated in this commit: https://github.com/singlecellopenproblems/SingleCellOpenProblems/commit/f1c84cbb64bdc3a183d6365b4a7cb85411f015c8, it is possible to run nextflow pipelines from a GitHub repository, which will automatically pull down the GitHub code.

Can pull a branch with `-r branchname`:

```
nextflow run owner/repo -r branchname
```

Can pull a hash (as this commit does: https://github.com/singlecellopenproblems/SingleCellOpenProblems/commit/f1c84cbb64bdc3a183d6365b4a7cb85411f015c8)

```
nextflow run owner/repo -r hash123
```

Can specify the branch and always pull the latest version:

```
nextflow run owner/repo -r main -latest
```

Hope that helps!