### PR TITLE
Add trustworthiness score for dimred task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ resources/
 # Nextflow
 nf-openproblems
 .nextflow
+
+# Editor
+.idea

--- a/openproblems/tasks/dimensionality_reduction/README.md
+++ b/openproblems/tasks/dimensionality_reduction/README.md
@@ -31,7 +31,7 @@ $$
     \sum_{j \in \mathcal{N}_{i}^{k}} \max(0, (r(i, j) - k)) 
 $$
 
-where for each sample i, :math:`\mathcal{N}_{i}^{k}` are its k nearest neighbors in the output space, and every sample j is its $r(i, j)$-th nearest neighbor in the input space. In other words, any unexpected nearest neighbors in the output space are penalised in proportion to their rank in the input space.
+where for each sample i, $\mathcal{N}_{i}^{k}$ are its k nearest neighbors in the output space, and every sample j is its $r(i, j)$-th nearest neighbor in the input space. In other words, any unexpected nearest neighbors in the output space are penalised in proportion to their rank in the input space.
 
 References:
     * "Neighborhood Preservation in Nonlinear Projection Methods: An Experimental Study" J. Venna, S. Kaski

--- a/openproblems/tasks/dimensionality_reduction/README.md
+++ b/openproblems/tasks/dimensionality_reduction/README.md
@@ -33,9 +33,9 @@ $$
 
 where for each sample i, $\mathcal{N}_{i}^{k}$ are its k nearest neighbors in the output space, and every sample j is its $r(i, j)$-th nearest neighbor in the input space. In other words, any unexpected nearest neighbors in the output space are penalised in proportion to their rank in the input space.
 
-References:
-    * "Neighborhood Preservation in Nonlinear Projection Methods: An Experimental Study" J. Venna, S. Kaski
-    * "Learning a Parametric Embedding by Preserving Local Structure" L.J.P. van der Maaten
+References:  
+    * "Neighborhood Preservation in Nonlinear Projection Methods: An Experimental Study" J. Venna, S. Kaski  
+    * "Learning a Parametric Embedding by Preserving Local Structure" L.J.P. van der Maaten  
 
 ## The results
 

--- a/openproblems/tasks/dimensionality_reduction/README.md
+++ b/openproblems/tasks/dimensionality_reduction/README.md
@@ -19,6 +19,24 @@ Where $y_i$ is the sum of pairwise euclidian distances between each value embedd
 
 <a href = "http://cda.psych.uiuc.edu/psychometrika_highly_cited_articles/kruskal_1964a.pdf">Kruskel's stress</a> uses the RMSE, more or less in the now commonly-used MDS (multi-dimensional scaling). We can calculate and plot Kruskel's stress to get an idea where the majority of distortion of the ***topography*** of the data in high-dimensional space.
 
+### Trustworthiness
+---
+
+Adapted from the [sklearn documentation.](https://scikit-learn.org/stable/modules/generated/sklearn.manifold.trustworthiness.html)
+
+Trustworthiness expresses to what extent the local structure in an embedding is retained. The trustworthiness is within [0, 1]. It is defined as
+
+$$
+    T(k) = 1 - \frac{2}{nk (2n - 3k - 1)} \sum^n_{i=1}
+    \sum_{j \in \mathcal{N}_{i}^{k}} \max(0, (r(i, j) - k)) 
+$$
+
+where for each sample i, :math:`\mathcal{N}_{i}^{k}` are its k nearest neighbors in the output space, and every sample j is its $r(i, j)$-th nearest neighbor in the input space. In other words, any unexpected nearest neighbors in the output space are penalised in proportion to their rank in the input space.
+
+References:
+    * "Neighborhood Preservation in Nonlinear Projection Methods: An Experimental Study" J. Venna, S. Kaski
+    * "Learning a Parametric Embedding by Preserving Local Structure" L.J.P. van der Maaten
+
 ## The results
 
 ![Stress-plot RMASE CITE-seq](https://i.imgur.com/ulyAF9j.png)

--- a/openproblems/tasks/dimensionality_reduction/README.md
+++ b/openproblems/tasks/dimensionality_reduction/README.md
@@ -22,7 +22,7 @@ Where $y_i$ is the sum of pairwise euclidian distances between each value embedd
 ### Trustworthiness
 ---
 
-Adapted from the [sklearn documentation.](https://scikit-learn.org/stable/modules/generated/sklearn.manifold.trustworthiness.html)
+_Adapted from the [sklearn documentation.](https://scikit-learn.org/stable/modules/generated/sklearn.manifold.trustworthiness.html)_
 
 Trustworthiness expresses to what extent the local structure in an embedding is retained. The trustworthiness is within [0, 1]. It is defined as
 

--- a/openproblems/tasks/dimensionality_reduction/metrics/__init__.py
+++ b/openproblems/tasks/dimensionality_reduction/metrics/__init__.py
@@ -1,1 +1,2 @@
 from .root_mean_square_error import rmse
+from .trustworthiness import trustworthiness

--- a/openproblems/tasks/dimensionality_reduction/metrics/trustworthiness.py
+++ b/openproblems/tasks/dimensionality_reduction/metrics/trustworthiness.py
@@ -1,0 +1,29 @@
+from ....tools.decorators import metric
+from anndata import AnnData
+from scipy.sparse import issparse
+from sklearn import manifold
+
+import numpy as np
+
+
+@metric(metric_name="trustworthiness", maximize=True)
+def trustworthiness(adata: AnnData) -> float:
+    high_dim, low_dim = adata.X, adata.obsm["X_emb"]
+
+    data = high_dim.data if issparse(high_dim) else high_dim
+    if np.any(~np.isfinite(data)):
+        # fault of the data
+        return float(np.nan)
+
+    if np.any(~np.isfinite(low_dim)):
+        # method's fault
+        return 0.0
+
+    score = manifold.trustworthiness(
+        high_dim, low_dim, n_neighbors=15, metric="euclidean"
+    )
+    # for large k close to #samples, it's higher than 1.0, e.g 1.0000073552559712
+    score = float(np.clip(score, 0, 1))
+    adata.uns["trustworthiness_score"] = score
+
+    return score

--- a/openproblems/tasks/dimensionality_reduction/metrics/trustworthiness.py
+++ b/openproblems/tasks/dimensionality_reduction/metrics/trustworthiness.py
@@ -1,6 +1,5 @@
 from ....tools.decorators import metric
 from anndata import AnnData
-from scipy.sparse import issparse
 from sklearn import manifold
 
 import numpy as np
@@ -10,20 +9,11 @@ import numpy as np
 def trustworthiness(adata: AnnData) -> float:
     high_dim, low_dim = adata.X, adata.obsm["X_emb"]
 
-    data = high_dim.data if issparse(high_dim) else high_dim
-    if np.any(~np.isfinite(data)):
-        # fault of the data
-        return float(np.nan)
-
     if np.any(~np.isfinite(low_dim)):
-        # method's fault
         return 0.0
 
     score = manifold.trustworthiness(
         high_dim, low_dim, n_neighbors=15, metric="euclidean"
     )
     # for large k close to #samples, it's higher than 1.0, e.g 1.0000073552559712
-    score = float(np.clip(score, 0, 1))
-    adata.uns["trustworthiness_score"] = score
-
-    return score
+    return float(np.clip(score, 0, 1))

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -47,6 +47,17 @@ def test_metric(task_name, metric_name, tempdir, image):
     assert isinstance(m, numbers.Number)
 
 
+@parameterized.parameterized.expand(
+    [
+        (
+            utils.TEMPDIR.name,
+            openproblems.tasks.dimensionality_reduction.metrics.trustworthiness.metadata[  # noqa: E501
+                "image"
+            ],
+        )
+    ],
+    name_func=utils.name.name_test,
+)
 @utils.docker.docker_test
 def test_trustworthiness_sparse(tempdir, image):
     from scipy.sparse import csr_matrix

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -45,3 +45,22 @@ def test_metric(task_name, metric_name, tempdir, image):
     )
     m = metric(adata)
     assert isinstance(m, numbers.Number)
+
+
+@utils.docker.docker_test
+def test_trustworthiness_sparse(tempdir, image):
+    from scipy.sparse import csr_matrix
+
+    task = openproblems.tasks.dimensionality_reduction
+    metric = openproblems.tasks.dimensionality_reduction.metrics.trustworthiness
+
+    adata = task.api.sample_dataset()
+    adata = task.api.sample_method(adata)
+    openproblems.log.debug(
+        "Testing {} metric from {} task".format(metric.__name__, task.__name__)
+    )
+    adata.X = csr_matrix(adata.X)
+    m = metric(adata)
+
+    assert isinstance(m, float)
+    assert 0 <= m <= 1


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Submission type

* [ ] This submission adds a new dataset
* [ ] This submission adds a new method
* [x] This submission adds a new metric
* [ ] This submission adds a new task
* [ ] This submission adds a new Docker image
* [ ] This submission fixes a bug (link to related issue: )
* [ ] This submission adds a new feature not listed above

### Testing

* [x] This submission was written on a forked copy of SingleCellOpenProblems
* [x] GitHub Actions "Run Benchmark" tests are passing on this base branch of this pull request (include link to passed test: )
  https://github.com/michalk8/SingleCellOpenProblems/actions/runs/698892182
* [x] If this pull request is not ready for review (including passing the "Run Benchmark" tests), I will open this PR as a draft (click on the down arrow next to the "Create Pull Request" button)

### Submission guidelines

* [x] This submission follows the guidelines in our [Contributing](../blob/master/CONTRIBUTING.md) document
* [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change

This PR adds trustworthiness score from `sklearn`.
Things that need to be resolved:
 - the method does not work if there are non-finite values in the embedding/original space. Current solution: if original space contains non-fin. values (e.g. NaN), return NaN,
if the embedding contains these values, 0 is return (lowest possible value for the score).
- locally, I've tested that it works also on sparse matrices (in case adata.X), but haven't added any test for this: should the test be added in `test_metrics.py`?
- following the RMSE-based score, I've also saved the trust. score to `adata.uns['trustworthiness_score']` - is this desired?

closes #254 