### PR TITLE
Dimred datasets preprocessing

### DIFF
--- a/openproblems/tasks/dimensionality_reduction/README.md
+++ b/openproblems/tasks/dimensionality_reduction/README.md
@@ -36,7 +36,7 @@ We can make this comparison across multiple dimensionality reduction methods. We
 
 ## API
 
-**Methods** should assign dimensionally-reduced 2D embedding coordinates to `adata.obsm['X_emb']` as well as the method of choice, i.e., `adata.obsm['X_pca']` or `adata.obsm['X_tsne']`.
+**Methods** should assign dimensionally-reduced 2D embedding coordinates to `adata.obsm['X_emb']` as well as the method of choice, i.e., `adata.obsm['X_pca']` or `adata.obsm['X_tsne']`. For most methods the input should be a pre-computed higher-dimensional embedding created as part of the data loader and stored in `adata.obsm['X_input']`.
 
 **Metrics** should calculate the quality or "goodness of fit" of a dimensional reduction **method**.
 

--- a/openproblems/tasks/dimensionality_reduction/api.py
+++ b/openproblems/tasks/dimensionality_reduction/api.py
@@ -5,6 +5,7 @@ import scanpy as sc
 
 def check_dataset(adata):
     """Check that dataset output fits expected API."""
+    assert "X_input" in adata.obsm
     return True
 
 

--- a/openproblems/tasks/dimensionality_reduction/datasets/citeseq.py
+++ b/openproblems/tasks/dimensionality_reduction/datasets/citeseq.py
@@ -1,7 +1,11 @@
 from ....data.multimodal.citeseq import load_citeseq_cbmc
 from ....tools.decorators import dataset
+from .preprocessing import preprocess_scanpy
 
 
 @dataset("CITE-seq Cord Blood Mononuclear Cells")
 def citeseq_cbmc(test=False):
-    return load_citeseq_cbmc(test=test)
+
+    adata = load_citeseq_cbmc(test=test)
+
+    return preprocess_scanpy(adata)

--- a/openproblems/tasks/dimensionality_reduction/datasets/human_blood_nestorowa2016.py
+++ b/openproblems/tasks/dimensionality_reduction/datasets/human_blood_nestorowa2016.py
@@ -1,9 +1,13 @@
 from ....data.human_blood_nestorowa2016 import load_human_blood_nestorowa2016
 from ....tools.decorators import dataset
+from .preprocessing import preprocess_scanpy
 
 
 @dataset(
     "Human blood (HSCs and differentiation thereof). Nestorowa, et al. Blood. 2016"
 )
 def human_blood_nestorowa2016(test=False):
-    return load_human_blood_nestorowa2016(test=test)
+
+    adata = load_human_blood_nestorowa2016(test=test)
+
+    return preprocess_scanpy(adata)

--- a/openproblems/tasks/dimensionality_reduction/datasets/preprocessing.py
+++ b/openproblems/tasks/dimensionality_reduction/datasets/preprocessing.py
@@ -5,6 +5,7 @@ def preprocess_scanpy(adata):
     sc.pp.normalize_total(adata)
     sc.pp.log1p(adata)
     sc.pp.highly_variable_genes(adata, n_top_genes=1000)
-    sc.tl.pca(adata, n_comps=50, svd_solver='arpack')
+    sc.tl.pca(adata, n_comps=50, svd_solver="arpack")
+    adata.obsm["X_input"] = adata.obsm["X_pca"]
 
     return adata

--- a/openproblems/tasks/dimensionality_reduction/datasets/preprocessing.py
+++ b/openproblems/tasks/dimensionality_reduction/datasets/preprocessing.py
@@ -1,5 +1,6 @@
 import scanpy as sc
 
+
 def preprocess_scanpy(adata):
 
     sc.pp.normalize_total(adata)

--- a/openproblems/tasks/dimensionality_reduction/datasets/preprocessing.py
+++ b/openproblems/tasks/dimensionality_reduction/datasets/preprocessing.py
@@ -1,0 +1,10 @@
+import scanpy as sc
+
+def preprocess_scanpy(adata):
+
+    sc.pp.normalize_total(adata)
+    sc.pp.log1p(adata)
+    sc.pp.highly_variable_genes(adata, n_top_genes=1000)
+    sc.tl.pca(adata, n_comps=50, svd_solver='arpack')
+
+    return adata

--- a/openproblems/tasks/dimensionality_reduction/datasets/tenx_5k_pbmc.py
+++ b/openproblems/tasks/dimensionality_reduction/datasets/tenx_5k_pbmc.py
@@ -2,6 +2,7 @@ from ....data.tenx_5k_pbmc import load_tenx_5k_pbmc
 from ....tools.decorators import dataset
 from .preprocessing import preprocess_scanpy
 
+
 @dataset(
     "5k Peripheral blood mononuclear cells (PBMCs) from a healthy donor. "
     "10x Genomics; July 24, 2019."

--- a/openproblems/tasks/dimensionality_reduction/datasets/tenx_5k_pbmc.py
+++ b/openproblems/tasks/dimensionality_reduction/datasets/tenx_5k_pbmc.py
@@ -1,10 +1,13 @@
 from ....data.tenx_5k_pbmc import load_tenx_5k_pbmc
 from ....tools.decorators import dataset
-
+from .preprocessing import preprocess_scanpy
 
 @dataset(
     "5k Peripheral blood mononuclear cells (PBMCs) from a healthy donor. "
     "10x Genomics; July 24, 2019."
 )
 def tenx_5k_pbmc(test=False):
-    return load_tenx_5k_pbmc(test=test)
+
+    adata = load_tenx_5k_pbmc(test=test)
+
+    return preprocess_scanpy(adata)

--- a/openproblems/tasks/dimensionality_reduction/methods/pca.py
+++ b/openproblems/tasks/dimensionality_reduction/methods/pca.py
@@ -14,6 +14,5 @@ import scanpy as sc
     code_version=check_version("scikit-learn"),
 )
 def pca(adata):
-    sc.tl.pca(adata)
     adata.obsm["X_emb"] = adata.obsm["X_pca"][:, :2]
     return adata

--- a/openproblems/tasks/dimensionality_reduction/methods/pca.py
+++ b/openproblems/tasks/dimensionality_reduction/methods/pca.py
@@ -14,5 +14,5 @@ import scanpy as sc
     code_version=check_version("scikit-learn"),
 )
 def pca(adata):
-    adata.obsm["X_emb"] = adata.obsm["X_pca"][:, :2]
+    adata.obsm["X_emb"] = adata.obsm["X_input"][:, :2]
     return adata

--- a/openproblems/tasks/dimensionality_reduction/methods/tsne.py
+++ b/openproblems/tasks/dimensionality_reduction/methods/tsne.py
@@ -15,6 +15,6 @@ import scanpy as sc
     image="openproblems-python-extras",
 )
 def tsne(adata):
-    sc.tl.tsne(adata, use_rep="X_pca", n_pcs=50)
+    sc.tl.tsne(adata, use_rep="X_input", n_pcs=50)
     adata.obsm["X_emb"] = adata.obsm["X_tsne"]
     return adata

--- a/openproblems/tasks/dimensionality_reduction/methods/tsne.py
+++ b/openproblems/tasks/dimensionality_reduction/methods/tsne.py
@@ -15,7 +15,6 @@ import scanpy as sc
     image="openproblems-python-extras",
 )
 def tsne(adata):
-    sc.pp.pca(adata)
-    sc.tl.tsne(adata)
+    sc.tl.tsne(adata, use_rep="X_pca", n_pcs=50)
     adata.obsm["X_emb"] = adata.obsm["X_tsne"]
     return adata

--- a/openproblems/tasks/dimensionality_reduction/methods/umap.py
+++ b/openproblems/tasks/dimensionality_reduction/methods/umap.py
@@ -14,7 +14,7 @@ import scanpy as sc
     code_version=check_version("umap-learn"),
 )
 def umap(adata):
-    sc.pp.neighbors(adata, use_rep="X_pca", n_pcs=50)
+    sc.pp.neighbors(adata, use_rep="X_input", n_pcs=50)
     sc.tl.umap(adata)
     adata.obsm["X_emb"] = adata.obsm["X_umap"]
     return adata

--- a/openproblems/tasks/dimensionality_reduction/methods/umap.py
+++ b/openproblems/tasks/dimensionality_reduction/methods/umap.py
@@ -14,7 +14,7 @@ import scanpy as sc
     code_version=check_version("umap-learn"),
 )
 def umap(adata):
-    sc.pp.neighbors(adata)
+    sc.pp.neighbors(adata, use_rep="X_pca", n_pcs=50)
     sc.tl.umap(adata)
     adata.obsm["X_emb"] = adata.obsm["X_umap"]
     return adata


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Submission type

This submission modifies the dimensionality reduction (2D) task to include pre-processing steps in the data loaders (See #279). These should store a higher dimensional embedding in `adata.obsm['X_input']` which is then used as the input for (most) methods.

* Add a `preprocessing.py` function that has pre-processing functions (one currently)
* Added that pre-processing function to the existing data loaders
* Modified the existing methods to use the pre-computed higher-dimensional embedding as input
  * `PHATE` is an exception, wasn't sure if that was appropriate so skipped for now but should probably discuss before merging
* Updated the API and README to describe the change

### Testing

* [x] This submission was written on a forked copy of SingleCellOpenProblems
* [ ] GitHub Actions "Run Benchmark" tests are passing on this base branch of this pull request (include link to passed test: ) **PENDING**
* [x] If this pull request is not ready for review (including passing the "Run Benchmark" tests), I will open this PR as a draft (click on the down arrow next to the "Create Pull Request" button)

### Submission guidelines

* [x] This submission follows the guidelines in our [Contributing](../blob/master/CONTRIBUTING.md) document
* [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change
