### PR TITLE
Dimred methods preprocessing

### DIFF
--- a/openproblems/tasks/dimensionality_reduction/README.md
+++ b/openproblems/tasks/dimensionality_reduction/README.md
@@ -40,4 +40,8 @@ We can make this comparison across multiple dimensionality reduction methods. We
 
 **Metrics** should calculate the quality or "goodness of fit" of a dimensional reduction **method**.
 
+## Pre-processing
+
+There is a `preprocessing.py` function which contains a set of standard pre-processing functions. These perform steps such as transforming the raw data, selecting features and summarising dimensionality reduction. Where possible each **method** should first call one of these functions and use the processed `adata.X` or `adata.obsm['X_input']` slot as the input to the method. Variants of methods can be created by applying different pre-processing prior to the method itself (see `phate.py` for an example).
+
 1. Raimundo, F., Vallot, C. & Vert, J. Tuning parameters of dimensionality reduction methods for single-cell RNA-seq analysis. Genome Biol 21, 212 (2020). https://doi.org/10.1186/s13059-020-02128-7

--- a/openproblems/tasks/dimensionality_reduction/methods/__init__.py
+++ b/openproblems/tasks/dimensionality_reduction/methods/__init__.py
@@ -1,4 +1,5 @@
 from .pca import pca
-from .phate import phate
+from .phate import phate_default
+from .phate import phate_scanpy
 from .tsne import tsne
 from .umap import umap

--- a/openproblems/tasks/dimensionality_reduction/methods/pca.py
+++ b/openproblems/tasks/dimensionality_reduction/methods/pca.py
@@ -2,8 +2,6 @@ from ....tools.decorators import method
 from ....tools.utils import check_version
 from .preprocessing import preprocess_scanpy
 
-import scanpy as sc
-
 
 @method(
     method_name="Principle Component Analysis (PCA)",

--- a/openproblems/tasks/dimensionality_reduction/methods/pca.py
+++ b/openproblems/tasks/dimensionality_reduction/methods/pca.py
@@ -1,5 +1,6 @@
 from ....tools.decorators import method
 from ....tools.utils import check_version
+from .preprocessing import preprocess_scanpy
 
 import scanpy as sc
 
@@ -14,6 +15,6 @@ import scanpy as sc
     code_version=check_version("scikit-learn"),
 )
 def pca(adata):
-    sc.tl.pca(adata)
-    adata.obsm["X_emb"] = adata.obsm["X_pca"][:, :2]
+    preprocess_scanpy(adata)
+    adata.obsm["X_emb"] = adata.obsm["X_input"][:, :2]
     return adata

--- a/openproblems/tasks/dimensionality_reduction/methods/phate.py
+++ b/openproblems/tasks/dimensionality_reduction/methods/phate.py
@@ -2,10 +2,11 @@ from ....tools.decorators import method
 from ....tools.normalize import sqrt_cpm
 from ....tools.utils import check_version
 from .preprocessing import preprocess_scanpy
-from phate import PHATE
 
 
 def _phate(adata):
+    from phate import PHATE
+
     phate_op = PHATE(verbose=False, n_jobs=-1)
     adata.obsm["X_emb"] = phate_op.fit_transform(adata.X)
     return adata

--- a/openproblems/tasks/dimensionality_reduction/methods/phate.py
+++ b/openproblems/tasks/dimensionality_reduction/methods/phate.py
@@ -1,10 +1,18 @@
 from ....tools.decorators import method
 from ....tools.normalize import sqrt_cpm
 from ....tools.utils import check_version
+from .preprocessing import preprocess_scanpy
 
+from phate import PHATE
+
+
+def _phate(adata):
+    phate_op = PHATE(verbose=False, n_jobs=-1)
+    adata.obsm["X_emb"] = phate_op.fit_transform(adata.X)
+    return adata
 
 @method(
-    method_name="PHATE",
+    method_name="PHATE (default pre-processing)",
     paper_name="Visualizing Transitions and Structure for Biological Data Exploration",
     paper_url="https://www.nature.com/articles/s41587-019-0336-3",
     paper_year=2019,
@@ -12,10 +20,19 @@ from ....tools.utils import check_version
     code_version=check_version("phate"),
     image="openproblems-python-extras",
 )
-def phate(adata):
-    from phate import PHATE
-
+def phate_default(adata):
     sqrt_cpm(adata)
-    phate_op = PHATE(verbose=False, n_jobs=-1)
-    adata.obsm["X_emb"] = phate_op.fit_transform(adata.X)
-    return adata
+    return _phate(adata)
+
+@method(
+    method_name="PHATE (scanpy pre-processing)",
+    paper_name="Visualizing Transitions and Structure for Biological Data Exploration",
+    paper_url="https://www.nature.com/articles/s41587-019-0336-3",
+    paper_year=2019,
+    code_url="https://github.com/KrishnaswamyLab/PHATE/",
+    code_version=check_version("phate"),
+    image="openproblems-python-extras",
+)
+def phate_scanpy(adata):
+    preprocess_scanpy(adata)
+    return _phate(adata)

--- a/openproblems/tasks/dimensionality_reduction/methods/phate.py
+++ b/openproblems/tasks/dimensionality_reduction/methods/phate.py
@@ -2,7 +2,6 @@ from ....tools.decorators import method
 from ....tools.normalize import sqrt_cpm
 from ....tools.utils import check_version
 from .preprocessing import preprocess_scanpy
-
 from phate import PHATE
 
 
@@ -10,6 +9,7 @@ def _phate(adata):
     phate_op = PHATE(verbose=False, n_jobs=-1)
     adata.obsm["X_emb"] = phate_op.fit_transform(adata.X)
     return adata
+
 
 @method(
     method_name="PHATE (default pre-processing)",
@@ -23,6 +23,7 @@ def _phate(adata):
 def phate_default(adata):
     sqrt_cpm(adata)
     return _phate(adata)
+
 
 @method(
     method_name="PHATE (scanpy pre-processing)",

--- a/openproblems/tasks/dimensionality_reduction/methods/preprocessing.py
+++ b/openproblems/tasks/dimensionality_reduction/methods/preprocessing.py
@@ -1,5 +1,6 @@
-import scanpy as sc
 from ....tools.normalize import log_cpm
+
+import scanpy as sc
 
 
 def preprocess_scanpy(adata):

--- a/openproblems/tasks/dimensionality_reduction/methods/preprocessing.py
+++ b/openproblems/tasks/dimensionality_reduction/methods/preprocessing.py
@@ -1,0 +1,10 @@
+import scanpy as sc
+from ....tools.normalize import log_cpm
+
+
+def preprocess_scanpy(adata):
+
+    log_cpm(adata)
+    sc.pp.highly_variable_genes(adata, n_top_genes=1000)
+    sc.tl.pca(adata, n_comps=50, svd_solver="arpack")
+    adata.obsm["X_input"] = adata.obsm["X_pca"]

--- a/openproblems/tasks/dimensionality_reduction/methods/tsne.py
+++ b/openproblems/tasks/dimensionality_reduction/methods/tsne.py
@@ -1,5 +1,6 @@
 from ....tools.decorators import method
 from ....tools.utils import check_version
+from .preprocessing import preprocess_scanpy
 
 import scanpy as sc
 
@@ -15,7 +16,7 @@ import scanpy as sc
     image="openproblems-python-extras",
 )
 def tsne(adata):
-    sc.pp.pca(adata)
-    sc.tl.tsne(adata)
+    preprocess_scanpy(adata)
+    sc.tl.tsne(adata, use_rep="X_input", n_pcs=50)
     adata.obsm["X_emb"] = adata.obsm["X_tsne"]
     return adata

--- a/openproblems/tasks/dimensionality_reduction/methods/umap.py
+++ b/openproblems/tasks/dimensionality_reduction/methods/umap.py
@@ -1,5 +1,6 @@
 from ....tools.decorators import method
 from ....tools.utils import check_version
+from .preprocessing import preprocess_scanpy
 
 import scanpy as sc
 
@@ -14,7 +15,8 @@ import scanpy as sc
     code_version=check_version("umap-learn"),
 )
 def umap(adata):
-    sc.pp.neighbors(adata)
+    preprocess_scanpy(adata)
+    sc.pp.neighbors(adata, use_rep="X_input", n_pcs=50)
     sc.tl.umap(adata)
     adata.obsm["X_emb"] = adata.obsm["X_umap"]
     return adata


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Submission type

Take 2 at adding standard pre-processing to the dimensionality (2D) task, replacing #289.

This submission modifies the dimensionality reduction (2D) task to include a script with standard pre-processing functions for use by methods (See #279). These should store a transformed expression matrix in `adata.X` and a higher dimensional embedding in `adata.obsm['X_input']` which is then used as the input for (most) methods.

* Add a `preprocessing.py` function that has pre-processing functions (one currently)
* Added that pre-processing function to the existing methods
  * Created a new variant of **PHATE** that uses the standard pre-processing
* Updated the README to describe the pre-processing step

### Testing

* [x] This submission was written on a forked copy of SingleCellOpenProblems
* [ ] GitHub Actions "Run Benchmark" tests are passing on this base branch of this pull request (include link to passed test: ) **PENDING**
* [ ] If this pull request is not ready for review (including passing the "Run Benchmark" tests), I will open this PR as a draft (click on the down arrow next to the "Create Pull Request" button)

### Submission guidelines

* [x] This submission follows the guidelines in our [Contributing](../blob/master/CONTRIBUTING.md) document
* [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change
